### PR TITLE
SFCNT-290 : Explicitly specify that weight, ecotax and tva should be properties of products

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+### 1.0.0
+
+First implementation of XSD specification

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,0 @@
-### 1.0.0
-
-First implementation of XSD specification

--- a/examples/full.xml
+++ b/examples/full.xml
@@ -15,7 +15,7 @@
       <!-- Mandatory : Quantity available for your product. -->
       <quantity>1</quantity>
       <!-- Optional : VAT applicable to your product (percent value) -->
-      <tva>19.0</tva>
+      <vat>19.0</vat>
       <!-- Optional : Ecotax applicable to your product -->
       <ecotax>0.56</ecotax>
       <!-- Optional : Weight of your product -->

--- a/examples/full.xml
+++ b/examples/full.xml
@@ -14,6 +14,12 @@
       <price>10</price>
       <!-- Mandatory : Quantity available for your product. -->
       <quantity>1</quantity>
+      <!-- Optional : VAT applicable to your product -->
+      <tva>19.0</tva>
+      <!-- Optional : Ecotax applicable to your product -->
+      <ecotax>0.56</ecotax>
+      <!-- Optional : Weight of your product -->
+      <weight>2.5</weight>
       <!-- Optional : Brand name and link to the brand page of your product. -->
       <brand>
         <name><![CDATA[ Fashion Manufacturer ]]></name>

--- a/examples/full.xml
+++ b/examples/full.xml
@@ -14,7 +14,7 @@
       <price>10</price>
       <!-- Mandatory : Quantity available for your product. -->
       <quantity>1</quantity>
-      <!-- Optional : VAT applicable to your product -->
+      <!-- Optional : VAT applicable to your product (percent value) -->
       <tva>19.0</tva>
       <!-- Optional : Ecotax applicable to your product -->
       <ecotax>0.56</ecotax>

--- a/feed.xsd
+++ b/feed.xsd
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="percent">
+    <xs:annotation>
+      <xs:documentation>The percent type specifies a value from 0 to 100.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:element name="catalog" type="catalogType"/>
   <xs:complexType name="catalogType">
     <xs:sequence>
@@ -118,7 +127,7 @@
       <xs:element type="xs:integer" name="quantity"/>
       <xs:element type="xs:decimal" name="price"/>
       <!-- the tva value below represents a percentage value -->
-      <xs:element type="xs:decimal" name="tva" minOccurs="0" />
+      <xs:element type="percent" name="tva" minOccurs="0" />
       <xs:element type="xs:decimal" name="weight" minOccurs="0" />
       <xs:element type="xs:decimal" name="ecotax" minOccurs="0" />
       <xs:element type="brandType" name="brand" minOccurs="0"/>

--- a/feed.xsd
+++ b/feed.xsd
@@ -126,8 +126,8 @@
       <xs:element type="xs:token" name="link" minOccurs="0"/>
       <xs:element type="xs:integer" name="quantity"/>
       <xs:element type="xs:decimal" name="price"/>
-      <!-- the tva value below represents a percentage value -->
-      <xs:element type="percent" name="tva" minOccurs="0" />
+      <!-- the vat value below represents a percentage value -->
+      <xs:element type="percent" name="vat" minOccurs="0" />
       <xs:element type="xs:decimal" name="weight" minOccurs="0" />
       <xs:element type="xs:decimal" name="ecotax" minOccurs="0" />
       <xs:element type="brandType" name="brand" minOccurs="0"/>

--- a/feed.xsd
+++ b/feed.xsd
@@ -117,6 +117,7 @@
       <xs:element type="xs:token" name="link" minOccurs="0"/>
       <xs:element type="xs:integer" name="quantity"/>
       <xs:element type="xs:decimal" name="price"/>
+      <!-- the tva value below represents a percentage value -->
       <xs:element type="xs:decimal" name="tva" minOccurs="0" />
       <xs:element type="xs:decimal" name="weight" minOccurs="0" />
       <xs:element type="xs:decimal" name="ecotax" minOccurs="0" />

--- a/feed.xsd
+++ b/feed.xsd
@@ -117,6 +117,9 @@
       <xs:element type="xs:token" name="link" minOccurs="0"/>
       <xs:element type="xs:integer" name="quantity"/>
       <xs:element type="xs:decimal" name="price"/>
+      <xs:element type="xs:decimal" name="tva" minOccurs="0" />
+      <xs:element type="xs:decimal" name="weight" minOccurs="0" />
+      <xs:element type="xs:decimal" name="ecotax" minOccurs="0" />
       <xs:element type="brandType" name="brand" minOccurs="0"/>
       <xs:element type="categoryType" name="category" minOccurs="0"/>
       <xs:element type="shippingsType" name="shippings" minOccurs="0"/>


### PR DESCRIPTION
### Link to ticket
https://shopping-feed.atlassian.net/browse/SFCNT-290

### Short description

We expect weight, ecotax and tva as properties : 
```xml
<product>
  <reference>ABC</reference>
  <tva>19.0</tva>
  <weight>2.5</weight>
  <ecotax>0.56</ecotax>
</product>
```

and not as attributes
```xml
<product>
  <reference>ABC</reference>
  ...
  <attributes>
    <attribute><name>tva</name><value>19.0</value></attribute>
    <attribute><name>weight</name><value>2.5</value></attribute>
    <attribute><name>ecotax</name><value>0.56</value></attribute>
  </attributes>  
</product>
```

Just to be clear, there is no validation that stops passing these 3 fields as attributes. I can't seem to figure out the right regular expression to use in XSD : 
- I have the [correct regex](https://stackoverflow.com/a/5540478/3650405) 
- that can be used as a [restriction for a defined type](https://www.tutorialspoint.com/xsd/xsd_restriction.htm)
- the problem is that XSD does not interpret `^` and `$` as any classic regex engine would; and that poses a problem

So the purpose of this PR is just to validate these fields, when they are present.

### How to test
`xmllint --noout --schema feed.xsd ./examples/full.xml`
(you can modify the xml to test different scenarios)