### PR TITLE
SFCNS-385 Add support for ecotax and weight

### DIFF
--- a/examples/full.xml
+++ b/examples/full.xml
@@ -70,6 +70,10 @@
           <gtin>123456789></gtin>
           <quantity>1</quantity>
           <price>10</price>
+          <!-- Optional : Ecotax applicable to your product; if none provided, the parent ecotax will be used -->
+          <ecotax>0.67</ecotax>
+          <!-- Optional : Weight of your product; if none provided, the parent weight will be used -->
+          <weight>3.5</weight>
           <discounts>
             <discount type="price">10</discount>
           </discounts>

--- a/feed.xsd
+++ b/feed.xsd
@@ -92,6 +92,8 @@
       <xs:element type="xs:token" name="gtin" minOccurs="0"/>
       <xs:element type="xs:integer" name="quantity"/>
       <xs:element type="xs:decimal" name="price"/>
+      <xs:element type="xs:decimal" name="weight" minOccurs="0" />
+      <xs:element type="xs:decimal" name="ecotax" minOccurs="0" />
       <xs:element type="shippingsType" name="shippings" minOccurs="0"/>
       <xs:element type="discountsType" name="discounts" minOccurs="0"/>
       <xs:element type="shippingType" name="shipping" minOccurs="0"/>


### PR DESCRIPTION
### Ticket
https://shopping-feed.atlassian.net/browse/SFCNS-385

### Short description
Add support for ecotax & weight at the variation level.
- the weight is already supported
- the ecotax is being implemented as we speak

### Next steps 
- allow [the feed generator](https://github.com/shoppingflux/php-feed-generator) to support these modifications; we already have [a PR](https://github.com/shoppingflux/php-feed-generator/pull/21) for the ecotax, but it still needs a bit of tweaking
- modify the Shoppingfeed import & export so as to handle the ecotax (the weight is already supported)